### PR TITLE
Fix PHP Notice when categories[id] isn't set / Handle multi select attributes

### DIFF
--- a/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
+++ b/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
@@ -393,21 +393,20 @@ class Tritac_ChannelEngine_Helper_Feed extends Mage_Core_Helper_Abstract {
 
 			foreach($additional['attributes'] as $code => $attribute)
 			{
-
 				if(isset($product[$code]) && !in_array($code, $additional['systemAttributes']))
 				{
-					$io->streamWrite('<' . $code . '>');
-
+					$value = $product[$code];
 					if(!empty($attribute['values']))
 					{
-						$io->streamWrite('<![CDATA[' . $attribute['values'][$product[$code]] . ']]>');
-					}
-					else
-					{
-						$io->streamWrite('<![CDATA[' . $product[$code] . ']]>');
+						$valueList = [];
+						foreach (explode(',', $value) as $key)
+						{
+							$valueList[] = $attribute['values'][$key];
+						}
+						$value = implode(', ', $valueList);
 					}
 
-					$io->streamWrite('</' . $code . '>');
+					$io->streamWrite('<' . $code . '><![CDATA[' . $value . ']]></' . $code . '>');
 				}
 			}
 			$io->streamWrite('</Attributes>');

--- a/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
+++ b/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
@@ -360,7 +360,10 @@ class Tritac_ChannelEngine_Helper_Feed extends Mage_Core_Helper_Abstract {
 				$categoryPath = null;
 
 				foreach($categoryPathIds as $id) {
-					if($id > 1 && $id != $store->getRootCategoryId()) {
+					if($id > 1
+						&& $id != $store->getRootCategoryId()
+						&& isset($categories[$id])
+					) {
 						$categoryPath .= !empty($categoryPath) ? ' > ' : '';
 						$categoryPath .= $categories[$id]['name'];
 					}


### PR DESCRIPTION
Fix PHP Notice when categories[id] isn't set. The collection of categories only has categories that are active and included in menu. This gives a notice when the parent category of a category isn't included in the menu.

![screen shot 2017-10-24 at 15 50 20](https://user-images.githubusercontent.com/9214557/31946790-14cd7614-b8d3-11e7-947e-c7df60a20be8.png)
