### PR TITLE
Collect quote totals only once

### DIFF
--- a/app/code/community/Tritac/ChannelEngine/Model/Observer.php
+++ b/app/code/community/Tritac/ChannelEngine/Model/Observer.php
@@ -274,17 +274,15 @@ class Tritac_ChannelEngine_Model_Observer
                     ->setCollectShippingRates(true)
                     ->setShippingMethod('channelengine_channelengine');
 
-                $quote->collectTotals();
+                // Set custom payment method
+                $quote->setIsSystem(true);
+                $quote->getPayment()->importData(array('method' => 'channelengine'));
 
                 // Set guest customer
                 $quote->setCustomerId(null)
                     ->setCustomerEmail($quote->getBillingAddress()->getEmail())
                     ->setCustomerIsGuest(true)
                     ->setCustomerGroupId(Mage_Customer_Model_Group::NOT_LOGGED_IN_ID);
-
-                // Set custom payment method
-                $quote->setIsSystem(true);
-                $quote->getPayment()->importData(array('method' => 'channelengine'));
 
                 // Save quote and convert it to new order
                 try

--- a/app/code/community/Tritac/ChannelEngine/Model/Observer.php
+++ b/app/code/community/Tritac/ChannelEngine/Model/Observer.php
@@ -274,15 +274,15 @@ class Tritac_ChannelEngine_Model_Observer
                     ->setCollectShippingRates(true)
                     ->setShippingMethod('channelengine_channelengine');
 
-                // Set custom payment method
-                $quote->setIsSystem(true);
-                $quote->getPayment()->importData(array('method' => 'channelengine'));
-
                 // Set guest customer
                 $quote->setCustomerId(null)
                     ->setCustomerEmail($quote->getBillingAddress()->getEmail())
                     ->setCustomerIsGuest(true)
                     ->setCustomerGroupId(Mage_Customer_Model_Group::NOT_LOGGED_IN_ID);
+
+                // Set custom payment method
+                $quote->setIsSystem(true);
+                $quote->getPayment()->importData(array('method' => 'channelengine'));
 
                 // Save quote and convert it to new order
                 try


### PR DESCRIPTION
I moved the lines that set the custom payment method up. This way
it will collect totals while setting the custom payment method.

Conclusion: Custom payment method is being set before the quote
totals are collected.