### PR TITLE
Manufacturer attribute is treated as a system attribute rather then an optional one

### DIFF
--- a/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
+++ b/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
@@ -528,7 +528,6 @@ class Tritac_ChannelEngine_Helper_Feed extends Mage_Core_Helper_Abstract {
 	    $mappedSystemAttributes = array(
 	        'sku',
 	        'name',
-	        'manufacturer',
 	        'description',
 	        'short_description',
 	        'price',
@@ -537,6 +536,12 @@ class Tritac_ChannelEngine_Helper_Feed extends Mage_Core_Helper_Abstract {
 	        'visibility',
 	        'msrp'
 	    );
+
+        $manufacturer = Mage::getResourceModel('catalog/eav_attribute')
+            ->loadByCode(Mage_Catalog_Model_Product::ENTITY, 'manufacturer');
+        if ($manufacturer->getId() !== null) {
+            $mappedSystemAttributes[] = $manufacturer->getAttributeCode();
+        }
 
 	    $hiddenSystemAttributes = array(
 	    	'msrp_display_actual_price_type',

--- a/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
+++ b/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
@@ -537,8 +537,8 @@ class Tritac_ChannelEngine_Helper_Feed extends Mage_Core_Helper_Abstract {
 	        'msrp'
 	    );
 
-        $manufacturer = Mage::getResourceModel('catalog/eav_attribute')
-            ->loadByCode(Mage_Catalog_Model_Product::ENTITY, 'manufacturer');
+        $manufacturer = Mage::getSingleton('eav/config')
+            ->getAttribute(Mage_Catalog_Model_Product::ENTITY, 'manufacturer');
         if ($manufacturer->getId() !== null) {
             $mappedSystemAttributes[] = $manufacturer->getAttributeCode();
         }


### PR DESCRIPTION
Currently `manufacturer` is treated as a system attribute, whereas it is actually an example attribute that you get together with the `color` attribute on a Magento 1 installation. This attribute can be deleted, and should not be loaded without checking for their existence first.

This pull request proposes a simple fix that checks if it exists before loading it.

Fixes #9 