### PR TITLE
Feature/ifff 495 copy parent product attr values to child products

### DIFF
--- a/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
+++ b/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
@@ -263,12 +263,12 @@ class Tritac_ChannelEngine_Helper_Feed extends Mage_Core_Helper_Abstract {
 
 		$childProducts = $childProductCollection->getItems();
 
-		$copyCustomAttributes = Mage::getStoreConfig('channelengine/optional/copy_attributes', $store);
-		$productAttributeData = $copyCustomAttributes ? array_intersect_key($productData, $customAttributes) : [];
+        $copyParentAttributes = Mage::getStoreConfig('channelengine/optional/copy_attributes', $store);
+        $additionalChildAttributeData = $copyParentAttributes ? array_intersect_key($productData, $customAttributes) : [];
 
 		foreach($childProducts as $child)
 		{
-			$childData = array_merge($productAttributeData, $child->getData());
+			$childData = array_merge($additionalChildAttributeData, $child->getData());
 
 			$childData['id'] = $childData['entity_id'];
 			$childData['parent_id'] = $productData['id'];

--- a/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
+++ b/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
@@ -263,7 +263,7 @@ class Tritac_ChannelEngine_Helper_Feed extends Mage_Core_Helper_Abstract {
 
 		$childProducts = $childProductCollection->getItems();
 
-        $copyParentAttributes = Mage::getStoreConfig('channelengine/optional/copy_attributes', $store);
+        $copyParentAttributes = Mage::getStoreConfig('channelengine/optional/copy_parent_attributes', $store);
         $additionalChildAttributeData = $copyParentAttributes ? array_intersect_key($productData, $customAttributes) : [];
 
 		foreach($childProducts as $child)

--- a/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
+++ b/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
@@ -263,9 +263,12 @@ class Tritac_ChannelEngine_Helper_Feed extends Mage_Core_Helper_Abstract {
 
 		$childProducts = $childProductCollection->getItems();
 
+        $copyCustomAttributes = Mage::getStoreConfig('channelengine/optional/copy_attributes', $store);
+        $productAttributeData = $copyCustomAttributes ? array_intersect_key($productData, $customAttributes) : [];
+
 		foreach($childProducts as $child)
 		{
-			$childData = $child->getData();
+			$childData = array_merge($productAttributeData, $child->getData());
 
 			$childData['id'] = $childData['entity_id'];
 			$childData['parent_id'] = $productData['id'];

--- a/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
+++ b/app/code/community/Tritac/ChannelEngine/Helper/Feed.php
@@ -263,8 +263,8 @@ class Tritac_ChannelEngine_Helper_Feed extends Mage_Core_Helper_Abstract {
 
 		$childProducts = $childProductCollection->getItems();
 
-        $copyCustomAttributes = Mage::getStoreConfig('channelengine/optional/copy_attributes', $store);
-        $productAttributeData = $copyCustomAttributes ? array_intersect_key($productData, $customAttributes) : [];
+		$copyCustomAttributes = Mage::getStoreConfig('channelengine/optional/copy_attributes', $store);
+		$productAttributeData = $copyCustomAttributes ? array_intersect_key($productData, $customAttributes) : [];
 
 		foreach($childProducts as $child)
 		{

--- a/app/code/community/Tritac/ChannelEngine/etc/system.xml
+++ b/app/code/community/Tritac/ChannelEngine/etc/system.xml
@@ -151,7 +151,7 @@
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <comment>
-                                <![CDATA[<span class="notice">Copies the custom attribute value's from configurable products to their children during feed generation.</span>]]>
+                                <![CDATA[<span class="notice">Copies the custom attribute value's from parent products to their children during feed generation.</span>]]>
                             </comment>
                             <sort_order>6</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/community/Tritac/ChannelEngine/etc/system.xml
+++ b/app/code/community/Tritac/ChannelEngine/etc/system.xml
@@ -146,8 +146,8 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </expected_date>
-                        <copy_attributes translate="label">
-                            <label>Copy attribute values to child products</label>
+                        <copy_parent_attributes translate="label">
+                            <label>Copy parent attribute values to child products</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <comment>
@@ -157,7 +157,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </copy_attributes>
+                        </copy_parent_attributes>
                     </fields>
                 </optional>
                 <diagnostics>

--- a/app/code/community/Tritac/ChannelEngine/etc/system.xml
+++ b/app/code/community/Tritac/ChannelEngine/etc/system.xml
@@ -146,6 +146,18 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </expected_date>
+                        <copy_attributes translate="label">
+                            <label>Copy attribute values to child products</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <comment>
+                                <![CDATA[<span class="notice">Copies the custom attribute value's from configurable products to their children during feed generation.</span>]]>
+                            </comment>
+                            <sort_order>6</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </copy_attributes>
                     </fields>
                 </optional>
                 <diagnostics>


### PR DESCRIPTION
Added a new feature that copies parent product attribute data over to their children.

In order to not change the existing behaviour of the module this feature must be enabled by changing a system config setting in the optional group.

